### PR TITLE
Add embedded module

### DIFF
--- a/lib/cfnvpn.rb
+++ b/lib/cfnvpn.rb
@@ -8,6 +8,7 @@ require 'cfnvpn/revoke'
 require 'cfnvpn/sessions'
 require 'cfnvpn/routes'
 require 'cfnvpn/share'
+require 'cfnvpn/embedded'
 
 module CfnVpn
   class Cli < Thor
@@ -41,6 +42,9 @@ module CfnVpn
 
     register CfnVpn::Share, 'share', 'share [name]', 'Provide a user with a s3 signed download for certificates and config'
     tasks["share"].options = CfnVpn::Share.class_options
+
+    register CfnVpn::Embedded, 'embedded', 'embedded [name]', 'Provide a user with a S3 signed download for config embedded with certificates'
+    tasks["embedded"].options = CfnVpn::Embedded.class_options
 
   end
 end

--- a/lib/cfnvpn/embedded.rb
+++ b/lib/cfnvpn/embedded.rb
@@ -1,0 +1,108 @@
+require 'cfnvpn/log'
+require 'cfnvpn/s3'
+
+module CfnVpn
+  class Embedded < Thor::Group
+    include Thor::Actions
+    include CfnVpn::Log
+
+    argument :name
+
+    class_option :profile, desc: 'AWS Profile'
+    class_option :region, default: ENV['AWS_REGION'], desc: 'AWS Region'
+    class_option :verbose, desc: 'set log level to debug', type: :boolean
+
+    class_option :bucket, required: true, desc: 'S3 bucket'
+    class_option :client_cn, required: true, desc: 'Client certificates to download'
+    class_option :ignore_routes, alias: :i, type: :boolean, desc: 'Ignore client VPN pushed routes and set routes in config file'
+
+    def self.source_root
+      File.dirname(__FILE__)
+    end
+
+    def set_loglevel
+      Log.logger.level = Logger::DEBUG if @options['verbose']
+    end
+
+    def create_config_directory
+      @build_dir = "#{ENV['HOME']}/.cfnvpn/#{@name}"
+      @config_dir = "#{@build_dir}/config"
+      Log.logger.debug("Creating config directory #{@config_dir}")
+      FileUtils.mkdir_p(@config_dir)
+    end
+
+    def download_certificates
+      download = true
+      if File.exists?("#{@config_dir}/#{@options['client_cn']}.crt")
+        download = yes? "Certificates for #{@options['client_cn']} already exist in #{@config_dir}. Do you want to download again? ", :green
+      end
+
+      if download
+        Log.logger.info "Downloading certificates for #{@options['client_cn']} to #{@config_dir}"
+        s3 = CfnVpn::S3.new(@options['region'],@options['bucket'],@name)
+        s3.get_object("#{@config_dir}/#{@options['client_cn']}.tar.gz")
+        cert = CfnVpn::Certificates.new(@build_dir,@name)
+        Log.logger.debug cert.extract_certificate(@options['client_cn'])
+      end
+    end
+
+    def download_config
+      vpn = CfnVpn::ClientVpn.new(@name,@options['region'])
+      @endpoint_id = vpn.get_endpoint_id()
+      Log.logger.debug "downloading client config for #{@endpoint_id}"
+      @config = vpn.get_config(@endpoint_id)
+      string = (0...8).map { (65 + rand(26)).chr.downcase }.join
+      @config.sub!(@endpoint_id, "#{string}.#{@endpoint_id}")
+    end
+
+    def add_routes
+      if @options['ignore_routes']
+        Log.logger.debug "Ignoring routes pushed by the client vpn"
+        @config.concat("\nroute-nopull\n")
+        vpn = CfnVpn::ClientVpn.new(@name,@options['region'])
+        routes = vpn.get_route_with_mask
+        Log.logger.debug "Found routes #{routes}"
+        routes.each do |r|
+          @config.concat("route #{r[:route]} #{r[:mask]}\n")
+        end
+        dns_servers = vpn.get_dns_servers()
+        if dns_servers.any?
+          Log.logger.debug "Found DNS servers #{dns_servers.join(' ')}"
+          @config.concat("dhcp-option DNS #{dns_servers.first}\n")
+        end
+      end
+    end
+
+    def embed_certs
+      cert = CfnVpn::Certificates.new(@build_dir,@name)
+      Log.logger.debug cert.extract_certificate(@options['client_cn'])
+      Log.logger.debug "Reading extracted certificate and private key"
+      key = File.read("#{@config_dir}/#{@options['client_cn']}.key")
+      crt = File.read("#{@config_dir}/#{@options['client_cn']}.crt")
+      Log.logger.debug "Embedding certificate and private key into config"
+      @config.concat("\n<key>\n#{key}\n</key>\n")
+      @config.concat("\n<cert>\n#{crt}\n</cert>\n")
+    end
+
+    def upload_embedded_config
+      @s3 = CfnVpn::S3.new(@options['region'],@options['bucket'],@name)
+      @s3.store_embedded_config(@config, @options['client_cn'])
+    end
+
+    def get_presigned_url
+      @cn = @options['client_cn']
+      @config_url = @s3.get_url("#{@name}_#{@cn}.config.ovpn")
+      Log.logger.debug "Config presigned url: #{@config_url}"
+    end
+    
+    def display_url
+      Log.logger.info "Share the below instructions with the user..."
+      say "\nDownload the embedded config from the below presigned URL which will expire in 1 hour."
+      say "\nConfig:\n"
+      say "\tcurl #{@config_url} > #{@name}_#{@cn}.config.ovpn", :cyan
+      say "\nOpen #{@name}_#{@cn}.config.ovpn with your favourite openvpn client."
+    end
+
+  end
+
+end

--- a/lib/cfnvpn/s3.rb
+++ b/lib/cfnvpn/s3.rb
@@ -53,5 +53,15 @@ module CfnVpn
       presigner.presigned_url(:get_object, params)
     end
 
+    def store_embedded_config(config, cn)
+      Log.logger.debug("uploading config to s3://#{@bucket}/#{@path}/#{@name}_#{cn}.config.ovpn")
+      @client.put_object({
+        body: config,
+        bucket: @bucket,
+        key: "#{@path}/#{@name}_#{cn}.config.ovpn",
+        tagging: "cfnvpn:name=#{@name}"
+      })
+    end
+
   end
 end


### PR DESCRIPTION
Allow a user to generate a config with the embedded certificate and key of an existing client. This will handle the embedding & also push to S3 and generate a pre-signed URL. This allows you to take the one file and import as is into a OVPN client.