### PR TITLE
support creating routes for multiple subnets

### DIFF
--- a/docs/slack-notifications.md
+++ b/docs/slack-notifications.md
@@ -24,7 +24,6 @@ cfn-vpn modify [name] --slack-webhook-url "https://hooks.slack.com/services/T000
 - `ROUTE_LIMIT_EXCEEDED`: no new routes can be added to the route table due to AWS route table limit
 - `AUTH_RULE_LIMIT_EXCEEDED`: no new authorization rules can be added to the rule list due to AWS auth rule limit
 - `RESOLVE_FAILED`: failed to resolve the provided dns entry
-- `RATE_LIMIT_EXCEEDED`: concurrent modifications of the route table is being rated limited
 - `SUBNET_NOT_ASSOCIATED`: no subnets are associated with the Client VPN
 - `QUOTA_INCREASE_REQUEST`: automatic quota increase made 
 

--- a/lib/cfnvpn/actions/embedded.rb
+++ b/lib/cfnvpn/actions/embedded.rb
@@ -50,11 +50,10 @@ module CfnVpn::Actions
 
     def download_config
       vpn = CfnVpn::ClientVpn.new(@name,@options['region'])
-      @endpoint_id = vpn.get_endpoint_id()
-      CfnVpn::Log.logger.debug "downloading client config for #{@endpoint_id}"
-      @config = vpn.get_config(@endpoint_id)
+      CfnVpn::Log.logger.debug "downloading client config for #{vpn.endpoint_id}"
+      @config = vpn.get_config()
       string = (0...8).map { (65 + rand(26)).chr.downcase }.join
-      @config.sub!(@endpoint_id, "#{string}.#{@endpoint_id}")
+      @config.sub!(vpn.endpoint_id, "#{string}.#{vpn.endpoint_id}")
     end
 
     def add_routes

--- a/lib/cfnvpn/actions/init.rb
+++ b/lib/cfnvpn/actions/init.rb
@@ -143,8 +143,7 @@ module CfnVpn::Actions
 
     def finish
       vpn = CfnVpn::ClientVpn.new(@name,@options['region'])
-      @endpoint_id = vpn.get_endpoint_id()
-      CfnVpn::Log.logger.info "Client VPN #{@endpoint_id} created. Run `cfn-vpn config #{@name}` to setup the client config"
+      CfnVpn::Log.logger.info "Client VPN #{vpn.endpoint_id} created. Run `cfn-vpn config #{@name}` to setup the client config"
     end
 
   end

--- a/lib/cfnvpn/actions/modify.rb
+++ b/lib/cfnvpn/actions/modify.rb
@@ -164,8 +164,7 @@ module CfnVpn::Actions
 
     def finish
       vpn = CfnVpn::ClientVpn.new(@name,@options['region'])
-      @endpoint_id = vpn.get_endpoint_id()
-      CfnVpn::Log.logger.info "Client VPN #{@endpoint_id} modified."
+      CfnVpn::Log.logger.info "Client VPN #{vpn.endpoint_id} modified."
     end
 
   end

--- a/lib/cfnvpn/actions/revoke.rb
+++ b/lib/cfnvpn/actions/revoke.rb
@@ -42,9 +42,8 @@ module CfnVpn::Actions
 
     def apply_rekocation_list
       vpn = CfnVpn::ClientVpn.new(@name,@options['region'])
-      endpoint_id = vpn.get_endpoint_id()
-      vpn.put_revoke_list(endpoint_id,"#{@cert_dir}/crl.pem")
-      CfnVpn::Log.logger.info("revoked client #{@options['client_cn']} from #{endpoint_id}")
+      vpn.put_revoke_list("#{@cert_dir}/crl.pem")
+      CfnVpn::Log.logger.info("revoked client #{@options['client_cn']} from #{vpn.endpoint_id}")
     end
 
   end

--- a/lib/cfnvpn/actions/sessions.rb
+++ b/lib/cfnvpn/actions/sessions.rb
@@ -29,20 +29,19 @@ module CfnVpn::Actions
       @build_dir = "#{CfnVpn.cfnvpn_path}/#{@name}"
     end
 
-    def get_endpoint
+    def setup
       @vpn = CfnVpn::ClientVpn.new(@name,@options['region'])
-      @endpoint_id = @vpn.get_endpoint_id()
     end
 
     def kill_session
       if !@options['kill'].nil?
-        sessions = @vpn.get_sessions(@endpoint_id)
+        sessions = @vpn.get_sessions()
         session = sessions.select { |s| s if s.connection_id  == @options['kill'] }.first
         if session.any? && session.status.code == "active"
           terminate = yes? "Terminate connection #{@options['kill']} for #{session.common_name}?", :yellow
           if terminate
             CfnVpn::Log.logger.info "Terminating connection #{@options['kill']} for #{session.common_name}"
-            @vpn.kill_session(@endpoint_id,@options['kill'])
+            @vpn.kill_session(@options['kill'])
           end
         else
           CfnVpn::Log.logger.error "Connection id #{@options['kill']} doesn't exist or is not active"
@@ -51,7 +50,7 @@ module CfnVpn::Actions
     end
 
     def display_sessions
-      sessions = @vpn.get_sessions(@endpoint_id)
+      sessions = @vpn.get_sessions()
       rows = sessions.collect do |s|
         [ s.common_name, s.connection_established_time, s.status.code, s.client_ip, s.connection_id, s.ingress_bytes, s.egress_bytes ]
       end

--- a/lib/cfnvpn/actions/share.rb
+++ b/lib/cfnvpn/actions/share.rb
@@ -26,11 +26,10 @@ module CfnVpn::Actions
 
     def copy_config_to_s3
       vpn = CfnVpn::ClientVpn.new(@name,@options['region'])
-      @endpoint_id = vpn.get_endpoint_id()
-      CfnVpn::Log.logger.debug "downloading client config for #{@endpoint_id}"
-      @config = vpn.get_config(@endpoint_id)
+      CfnVpn::Log.logger.debug "downloading client config for #{vpn.endpoint_id}"
+      @config = vpn.get_config()
       string = (0...8).map { (65 + rand(26)).chr.downcase }.join
-      @config.sub!(@endpoint_id, "#{string}.#{@endpoint_id}")
+      @config.sub!(vpn.endpoint_id, "#{string}.#{vpn.endpoint_id}")
     end
 
     def add_routes

--- a/lib/cfnvpn/actions/subnets.rb
+++ b/lib/cfnvpn/actions/subnets.rb
@@ -61,13 +61,9 @@ module CfnVpn::Actions
       end
     end
 
-    def get_endpoint
-      @vpn = CfnVpn::ClientVpn.new(@name,@options['region'])
-      @endpoint_id = @vpn.get_endpoint_id()
-    end
-
     def associations
-      associations = @vpn.get_associations(@endpoint_id)
+      vpn = CfnVpn::ClientVpn.new(@name,@options['region'])
+      associations = vpn.get_associations()
       table = Terminal::Table.new(
         :headings => ['ID', 'Subnet', 'Status', 'CIDR', 'AZ', 'Groups'],
         :rows => associations.map {|ass| ass.values})

--- a/lib/cfnvpn/clientvpn.rb
+++ b/lib/cfnvpn/clientvpn.rb
@@ -5,6 +5,7 @@ require 'netaddr'
 module CfnVpn
   class ClientVpn
     
+    attr_reader :endpoint_id
 
     def initialize(name,region)
       @client = Aws::EC2::Client.new(region: region)
@@ -31,56 +32,71 @@ module CfnVpn
       return get_endpoint().dns_servers
     end
 
-    def get_config(endpoint_id)
+    def get_config()
       resp = @client.export_client_vpn_client_configuration({
-        client_vpn_endpoint_id: endpoint_id
+        client_vpn_endpoint_id: @endpoint_id
       })
       return resp.client_configuration
     end
 
-    def get_rekove_list(endpoint_id)
+    def get_rekove_list()
       resp = @client.export_client_vpn_client_certificate_revocation_list({
-        client_vpn_endpoint_id: endpoint_id
+        client_vpn_endpoint_id: @endpoint_id
       })
       return resp.certificate_revocation_list
     end
 
-    def put_revoke_list(endpoint_id,revoke_list)
+    def put_revoke_list(revoke_list)
       list = File.read(revoke_list)
       @client.import_client_vpn_client_certificate_revocation_list({
-        client_vpn_endpoint_id: endpoint_id,
+        client_vpn_endpoint_id: @endpoint_id,
         certificate_revocation_list: list
       })
     end
 
-    def get_sessions(endpoint_id)
+    def get_sessions()
       params = {
-        client_vpn_endpoint_id: endpoint_id,
+        client_vpn_endpoint_id: @endpoint_id,
         max_results: 20
       }
       resp = @client.describe_client_vpn_connections(params)
       return resp.connections
     end
 
-    def kill_session(endpoint_id, connection_id)
+    def kill_session(connection_id)
       @client.terminate_client_vpn_connections({
-        client_vpn_endpoint_id: endpoint_id,
+        client_vpn_endpoint_id: @endpoint_id,
         connection_id: connection_id
       })
     end
 
-    def get_routes()
-      endpoint_id = get_endpoint_id()
-      resp = @client.describe_client_vpn_routes({
-        client_vpn_endpoint_id: endpoint_id,
-        max_results: 20
-      })
-      return resp.routes
+    def get_routes(dns_route=nil)
+      routes = []
+      @client.describe_client_vpn_routes({client_vpn_endpoint_id: @endpoint_id}).each do |resp|
+        if dns_route
+          routes.concat resp.routes.select {|route| route.description.include?(dns_route) }
+        else
+          routes.concat resp.routes
+        end
+      end
+      return routes
     end
 
-    def get_groups_for_route(endpoint, cidr)
+    def get_auth_rules(dns_route=nil)
+      rules = []
+      @client.describe_client_vpn_authorization_rules({client_vpn_endpoint_id: @endpoint_id}) do |resp|
+        if dns_route
+          rules.concat resp.authorization_rules.select {|rule| rule.description.include?(dns_route) }
+        else
+          rules.concat resp.routes
+        end
+      end
+      return rules
+    end
+
+    def get_groups_for_route(cidr)
       auth_resp = @client.describe_client_vpn_authorization_rules({
-        client_vpn_endpoint_id: endpoint,
+        client_vpn_endpoint_id: @endpoint_id,
         filters: [
           {
             name: 'destination-cidr',
@@ -91,10 +107,10 @@ module CfnVpn
       return auth_resp.authorization_rules.map {|rule| rule.group_id }
     end
 
-    def get_associations(endpoint)
+    def get_associations()
       associations = []
       resp = @client.describe_client_vpn_target_networks({
-        client_vpn_endpoint_id: endpoint
+        client_vpn_endpoint_id: @endpoint_id
       })
 
       resp.client_vpn_target_networks.each do |net|
@@ -102,7 +118,7 @@ module CfnVpn
           subnet_ids: [net.target_network_id]
         })
         subnet = subnet_resp.subnets.first
-        groups = get_groups_for_route(endpoint, subnet.cidr_block)
+        groups = get_groups_for_route(subnet.cidr_block)
         
         associations.push({
           association_id: net.association_id,

--- a/lib/cfnvpn/templates/lambdas/auto_route_populator/states.py
+++ b/lib/cfnvpn/templates/lambdas/auto_route_populator/states.py
@@ -7,7 +7,6 @@ EXPIRED_ROUTE: cidr is no longer associated with DNS entry and is removed from t
 ROUTE_LIMIT_EXCEEDED: no new routes can be added to the route table due to aws route table limit
 AUTH_RULE_LIMIT_EXCEEDED: no new authorization rules can be added to the rule list due to aws auth rule limit
 RESOLVE_FAILED: failed to resolve the provided dns entry
-RATE_LIMIT_EXCEEDED: concurrent modifications of the route table is being rated limited
 SUBNET_NOT_ASSOCIATED: no subnets are associated with the client vpn
 QUOTA_INCREASE_REQUEST: automatic quota increase made
 """
@@ -18,6 +17,5 @@ EXPIRED_ROUTE = 'EXPIRED_ROUTE'
 ROUTE_LIMIT_EXCEEDED = 'ROUTE_LIMIT_EXCEEDED'
 AUTH_RULE_LIMIT_EXCEEDED = 'AUTH_RULE_LIMIT_EXCEEDED'
 RESOLVE_FAILED = 'RESOLVE_FAILED'
-RATE_LIMIT_EXCEEDED = 'RATE_LIMIT_EXCEEDED'
 SUBNET_NOT_ASSOCIATED = 'SUBNET_NOT_ASSOCIATED'
 QUOTA_INCREASE_REQUEST = 'QUOTA_INCREASE_REQUEST'


### PR DESCRIPTION
- When creating routes (dns and static) change the default behavior of creating a route with single subnet when multiple subnets have been assigned to the vpn to creating routes for all subnets assigned to the vpn.
- reduce the amount of api calls to the AWS API to retrieve the vpn endpoint id when the initializer will do this by exposing the endpoint_id attribute
- automatically change routes to create routes all assigned subnets when updating