### PR TITLE
Fix param-yaml reference in docs

### DIFF
--- a/docs/modifying.md
+++ b/docs/modifying.md
@@ -34,7 +34,7 @@ cfn-vpn params [name] --diff-yaml cfnvpn.[name].yaml
 cfn-vpn configuration can be managed through a YAML file using the `modify` command to apply the config changes to the vpn stack. See the [YAML docs](yaml-config.md) for config options.
 
 ```
-cfn-vpn modify [name] --params-yaml cfnvpn.[name].yaml
+cfn-vpn modify [name] --param-yaml cfnvpn.[name].yaml
 ```
 
 a cloudformation changeset is created with the desired changes and approval is asked

--- a/docs/yaml-config.md
+++ b/docs/yaml-config.md
@@ -7,7 +7,7 @@ cfn-vpn configuration can be managed through a YAML file using the `modify` comm
 run the `modify` command and supply the yaml file to apply the changes
 
 ```sh
-cfn-vpn routes [name] --params-yaml cfnvpn.[name].yaml
+cfn-vpn routes [name] --param-yaml cfnvpn.[name].yaml
 ```
 
 ## Dump Current Config to YAML File


### PR DESCRIPTION
This is not the name of the option, if you use `--params-yaml` the yaml file will be ignored and the command will return an error from CloudFormation about a failed change set due to there being no changes.

Example:
```
cfn-vpn modify myvpn --params-yaml cfnvpn.myvpn-ci2.yaml --region us-west-2
INFO: - Creating cloudformation changeset for stack myvpn-cfnvpn in us-west-2
ERROR: - change set status: FAILED reason: The submitted information didn't contain changes. Submit different information to create a change set.
```

Looking at the code [here](https://github.com/base2Services/cfn-vpn/blob/b0855e48f79ee1490c0049d13cd143cc35dfaf26/lib/cfnvpn/actions/modify.rb#L74) it is meant to be `param-yaml`.

You could argue that this is a better name for the option, and perhaps the command should be changed, but the smaller change is to change the docs.